### PR TITLE
add cairo and imagemagick information to debugging

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -136,6 +136,8 @@ the following steps happen in series. the tasks in each step are executed concur
 
 if you want to print debugging statements, `shots` uses `debug`, so you can do `DEBUG=shots node app` and you'll see tons of debug information pop into your screen.
 
+you need `cairo` bindings installed and `imagemagick` installed and available in your path.
+
 # license
 
 mit


### PR DESCRIPTION
Cairo and Imagemagick must be installed on your system for shots to function correctly.
