### PR TITLE
Catch screenshot errors, making sure the app can continue.

### DIFF
--- a/index.babel.js
+++ b/index.babel.js
@@ -167,6 +167,7 @@ function shots (options = {}) {
             )
           )))
         )))
+      .catch(reason => d(`ERR! ${reason}`))
       ), d(`shot chunk reducer, len=${chunks.length}`, Promise.resolve())))
     ))
     .then(maybe('diffing', diffingStage, () =>

--- a/index.js
+++ b/index.js
@@ -254,6 +254,8 @@ function shots() {
             return d('renaming streams, len=' + streams.length, Promise.all(streams.map(function (stream) {
               return d('renaming ' + stream.filename, prename((0, _path.join)(screenshots, stream.filename), (0, _path.join)(screenshots, stream.filename.replace(pages.replace(rsep, '!') + '!', '').replace(/\.html(-[\dx]+)[\w-]*\.png$/, '$1.html.png'))));
             })));
+          }).catch(function (reason) {
+            return d('ERR! ' + reason);
           });
         });
       }, d('shot chunk reducer, len=' + chunks.length, Promise.resolve()));
@@ -383,7 +385,7 @@ function shots() {
 
   function maybe(name, enabled, op) {
     return enabled ? function () {
-      return d('resolving ' + name + ' stage', op());
+      return d('entering ' + name + ' stage', op());
     } : function () {
       return d('skipping ' + name + ' stage', Promise.resolve());
     };


### PR DESCRIPTION
As described in #10, running into a single javascript error while screenshotting aborts the entire program.
Needless to say, I don't think this is good behavior, and as such, I added that a screenshot error will get caught in the screenshot stage, preventing it from bottling up to the fatal error exception handler.
